### PR TITLE
把“欢迎来到南外校友黑板报”改为“欢迎来到南京外国语学校校友会黑板报”，把“南外建站学习小组”改为“南外校友建站学习小组”

### DIFF
--- a/client/templates/coding-group/coding-group.html
+++ b/client/templates/coding-group/coding-group.html
@@ -1,7 +1,7 @@
 <template name="codingGroupHome">
   <div>
     <div class="page-header">
-      <h1>南外建站学习小组的家</h1>
+      <h1>南外校友建站学习小组的家</h1>
       <p>
         我们是一群来自世界各地的南外新老校友，
         组成志愿团队共同建立和维护南外校友相关的网站。

--- a/client/templates/home/home.html
+++ b/client/templates/home/home.html
@@ -1,10 +1,10 @@
 <template name="home">
   <div class="template-home">
     <div class="page-header">
-      <h1>欢迎来到南外校友黑板报</h1>
+      <h1>欢迎来到南京外国语学校校友会黑板报</h1>
     </div>
     <p>
-      黑板报由<a href="/coding-group">南外建站学习小组</a>维护，旨在给广大校友提供一些有用服务的基础平台。在黑板报上，你可以：
+      黑板报由<a href="/coding-group">南外校友建站学习小组</a>维护，旨在给广大校友提供一些有用服务的基础平台。在黑板报上，你可以：
       <ul>
         <li>搜校友</li>
         <li>看照片</li>


### PR DESCRIPTION
1. 主页修改：“欢迎来到南外校友黑板报”改为“欢迎来到南京外国语学校校友会黑板报”，“南外建站学习小组”改为“南外校友建站学习小组”。
2. 建站小组页面修改：“南外建站学习小组的家”改为“南外校友建站学习小组的家”。

修改原因：其一，以“南外”为简称的学校太多，网站一些关键的地方建议使用“南京外国语学校”全称；其二，建站小组是校友自发组成的，不隶属于南外校方，所以在“南外建站学习小组”中间添加“校友”二字，以表明身份。